### PR TITLE
Included "addons" property

### DIFF
--- a/CircularGauge.js
+++ b/CircularGauge.js
@@ -129,7 +129,15 @@ define(["jquery", "text!./scripts/style.css", "./scripts/themes", "./scripts/d3.
                             }
                         }
                     }
-                }
+                },
+                addons: {
+					uses: "addons",
+					items: {
+						dataHandling: {
+							uses: "dataHandling"
+						}
+					}
+				}
             }
         },
         snapshot: {


### PR DESCRIPTION
Included "addons" property in the extension definition. This allows users to:
-  set a calculation condition to conditionally show/hide the extension
- use the "include zero values" flag to include/exclude zero values